### PR TITLE
Fix mobile projects navigation overlap

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -214,7 +214,7 @@ const config = {
               },
               {
                 label: 'Projects',
-                to: '/syllabus/projects',
+                to: '/syllabus/projects/intro',
               },
               {
                 label: 'Documentation',

--- a/documentation/src/css/custom.css
+++ b/documentation/src/css/custom.css
@@ -492,20 +492,12 @@ html:not([data-theme='dark']) .stakeholders figure + figure {
   .stakeholders figure { border-top: 1px solid var(--divider); }
 }
 
-/* Keep in DOM for crawlers, hide from humans */
-/*.pdf-crawler-only {*/
-/*  position: absolute !important;*/
-/*  left: -10000px !important;*/
-/*  top: auto !important;*/
-/*  width: 1px !important;*/
-/*  height: 1px !important;*/
-/*  overflow: hidden !important;*/
-/*  */
-/*}*/
 .pdf-crawler-only {
-  position: fixed !important;
-  top: 0 !important;
-  left: 0 !important;
-  opacity: 0 !important;
-  z-index: 999999 !important;
+  position: absolute !important;
+  left: -10000px !important;
+  top: auto !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  pointer-events: none !important;
 }

--- a/documentation/src/theme/DocPaginator/index.tsx
+++ b/documentation/src/theme/DocPaginator/index.tsx
@@ -77,7 +77,7 @@ const isPdf =
       )
   );
 
-  if (shouldHideNextCompletely) {
+  if (shouldHideNextCompletely || (shouldHideNextVisually && !isPdf)) {
     next = undefined;
   }
 
@@ -104,7 +104,7 @@ const isPdf =
         {next && (
             <div
                 className={clsx(
-                    shouldHideNextVisually && 'pdf-crawler-only'
+                    shouldHideNextVisually && isPdf && 'pdf-crawler-only'
                 )}
             >
               <PaginatorNavLink

--- a/documentation/static/slides/manifest.json
+++ b/documentation/static/slides/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-14T18:08:12.541Z",
+  "generatedAt": "2026-05-14T18:35:49.646Z",
   "groupBy": "week",
   "groupBasePath": "weeks",
   "totalSlides": 0,

--- a/documentation/static/slides/manifest.json
+++ b/documentation/static/slides/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-13T17:59:20.405Z",
+  "generatedAt": "2026-05-14T18:08:12.541Z",
   "groupBy": "week",
   "groupBasePath": "weeks",
   "totalSlides": 0,

--- a/documentation/syllabus/grading-evaluation.mdx
+++ b/documentation/syllabus/grading-evaluation.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-previous: /syllabus/projects/intro
+pagination_prev: projects/intro
 ---
 
 import Figure from "../src/components/Figure";

--- a/documentation/syllabus/grading-evaluation.mdx
+++ b/documentation/syllabus/grading-evaluation.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-previous: /syllabus/projects
+previous: /syllabus/projects/intro
 ---
 
 import Figure from "../src/components/Figure";

--- a/documentation/syllabus/projects/intro.mdx
+++ b/documentation/syllabus/projects/intro.mdx
@@ -1,8 +1,9 @@
 ---
 sidebar_position: 2
 showEdit: false
-hideNext: true
-nextTitle: Future of Work
+hideNextVisually: true
+next: /syllabus/projects/soon
+nextTitle: TBD
 ---
 
 import Admonition from '@theme/Admonition';
@@ -32,13 +33,3 @@ Find your section below and learn about the real-world domain you’ll be workin
 [//]: # (Be flexible with programming languages and technologies like JavaScript, Python, React, Next.js, and Docker, choosing what best fits your project.)
 
 [//]: # (:::)
-
-<nav className="pagination-nav" aria-label="Docs pages">
-  <a
-    className="pagination-nav__link pagination-nav__link--next pdf-crawler-only"
-    href="/syllabus/projects/section-1"
-  >
-    <div className="pagination-nav__sublabel">Continue Reading</div>
-    <div className="pagination-nav__label">Future of Work</div>
-  </a>
-</nav>


### PR DESCRIPTION
Recording of bug being fixed: https://us.posthog.com/shared/_ZnestwZjASOlbqmLOd0uih3ekdhJQ?t=107 

This bug was due to my heavily changing how Docusaurus handles `nextPage`. I wanted to have full control so that students would have to take the step from their project section to the grading section seamlessly. This added the unintentional 404 bug because I both didn’t specify the next page properly, but I was also developing against a PDF crawler that is looking for that next page button to generate a PDF version of the syllabus. 