### PR TITLE
Refine showcase layout, filtering, and collaborator metadata

### DIFF
--- a/documentation/src/data/project.schema.json
+++ b/documentation/src/data/project.schema.json
@@ -12,6 +12,14 @@
       "type": "array",
       "items": { "type": "string" }
     },
+    "members": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "highlights": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
     "semester": { "type": "string" },
     "website": { "type": "string", "format": "uri" },
     "documentation": { "type": "string", "format": "uri" },
@@ -21,4 +29,3 @@
   },
   "additionalProperties": false
 }
-

--- a/documentation/src/data/projects/_index.json
+++ b/documentation/src/data/projects/_index.json
@@ -4,6 +4,13 @@
     "slug": "from-sketch-to-screen-rahad-arman-nabid",
     "description": "A collaborative UI design tool tailored for non-programmers. It allows multiple users to sketch interfaces, render designs in real time, finalize CSS, and specify page interactions—all without needing coding skills.",
     "contact": "rahad@example.com",
+    "members": [
+      "Rahad Arman Nabid"
+    ],
+    "highlights": [
+      "Real-time collaboration",
+      "No-code UI prototyping"
+    ],
     "tags": [
       "aac",
       "design",

--- a/documentation/src/data/showcase.ts
+++ b/documentation/src/data/showcase.ts
@@ -265,6 +265,7 @@ export type Project = {
   semester?: string;
   slug?: string;
   members?: string[];
+  highlights?: string[];
   repo?: string;
   useDocsAsPreview?: boolean;
 };
@@ -280,6 +281,14 @@ export const projects: Project[] = [
     tags: ['chatbot', 'ai', 'web', 'python', 'mongodb', 'slack', 'social'],
     semester: 'Spring 2026',
     slug: 'bereal-chatbot',
+    members: [
+      'Justin Pham',
+      'Khai Thach',
+      'John Livezey',
+      'Chris Breeden',
+      'Nathan Hollick',
+      'Carl Pierre-Louis',
+    ],
     useDocsAsPreview: true,
   },
   {
@@ -291,6 +300,13 @@ export const projects: Project[] = [
     tags: ['aac', 'accessibility', 'games','api', 'communication','library','speech-to-text'],
     semester: 'Fall 2025',
     slug: 'aaccommodate',
+    members: [
+      'Michael Colbert',
+      'Jessica Hutchison',
+      'Hena Patel',
+      'Gino Russo',
+      'Tam Trang',
+    ],
     useDocsAsPreview: false,
   },
   {
@@ -303,6 +319,13 @@ export const projects: Project[] = [
     tags: ['game', 'accessibility', 'multiplayer', 'aac', 'research'],
     semester: 'Summer 2025',
     slug: 'hip-io',
+    members: [
+      'Arvindh Velrajan',
+      'Mohammed Karim',
+      'Kostandin Jorgji',
+      'Jasmine Liu',
+      'Omais Khan',
+    ],
     useDocsAsPreview: true,
   },
   {

--- a/documentation/src/data/showcase.ts
+++ b/documentation/src/data/showcase.ts
@@ -338,6 +338,8 @@ export const projects: Project[] = [
     tags: ['ai', 'education', 'vscode-extension','research'],
     semester: 'Spring 2025',
     slug: 'clover',
+    members: ['Jaime Nguyen', 'Antonio M Mongeluzi', 'Sophia Mettille', 'Nick Rucinski', 'Jack Martin'],
+
   },
   {
     title: 'OrderUp',
@@ -349,6 +351,7 @@ export const projects: Project[] = [
     tags: ['game', 'accessibility', 'aac', 'education','research', 'multiplayer'],
     semester: 'Spring 2025',
     slug: 'order-up',
+    members: ['Seth Bernstein', 'Akhil Kasturi', 'Matt Littlefield', 'Andriy Luchko', 'TJ McBride', 'Addison Migash', 'Jonathan Zhang'],
   },
   {
     title: 'Piglet Prep',
@@ -360,6 +363,7 @@ export const projects: Project[] = [
     tags: ['education', 'ml', 'computer-vision', 'analytics', 'research','nextjs'],
     semester: 'Spring 2025',
     slug: 'piglet-prep',
+    members: ['Hirab Abdourazak', 'Noel Chacko', 'Henry Nguyen', 'Andrew Tran', 'Sophie Chen', 'Ernest Wong'],
     // useDocsAsPreview: true,
   },
   {
@@ -371,6 +375,7 @@ export const projects: Project[] = [
     demo: 'https://www.youtube.com/watch?v=j1K0Ypl_iDk&t=5325',
     semester: 'Spring 2025',
     slug: 'biogenie',
+    members: ['Keith C Bunn', 'Amitai Goldmeer', 'Ishmam Kabir', 'Khanh Q Nguyen', 'Katerina Orlovskiy', 'Justin Truong', 'Troy K Witmer'],
   },
   {
     title: 'Whiteboard Assistant',
@@ -382,6 +387,7 @@ export const projects: Project[] = [
     tags: ['education','ai', 'interview-prep', 'web','pwa'],
     semester: 'Fall 2024',
     slug: 'whiteboard-assistant',
+    members: ['Dean Roos', 'Ben Stephenson', 'Vince Lukban', 'Renxuan Yao', 'Dhruvil Patel'],
     // useDocsAsPreview: true
   },
   {
@@ -393,6 +399,7 @@ export const projects: Project[] = [
     tags: ['gaming', 'education', 'hardware', 'raspberry-pi', 'embedded','pwa'],
     semester: 'Spring 2024',
     slug: 'blastpad',
+    members: ['Jacob Snarr', 'Neil Conley', 'Jeffin Johnykutty', 'Mustafa Wedee', 'Mustafa Malik', 'Niaz Baharudeen', 'Aiden McGonagle'],
   },
   {
     title: 'Wildlife Odyssey',
@@ -402,6 +409,7 @@ export const projects: Project[] = [
     semester: 'Spring 2024',
     slug: 'wildlife-odyssey',
     tags: ['game', 'multiplayer', 'unity','csharp', "matlab"],
+    members: ['Eddy Pike', 'Alex McGinn', 'Brandon Cuevas', 'Theron Halsey', 'Luigi Mazzocchi', 'Brian Barnefiher', 'Andrew Tran'],
   },
   {
     title: 'SmartSpeech',
@@ -414,6 +422,7 @@ export const projects: Project[] = [
     semester: 'Fall 2023',
     useDocsAsPreview: true,
     slug: 'smartspeech',
+    members: ['Parth Patel', 'Landen Lloyd', 'Zeshan Ahmad', 'Anthony Roman', 'Cynthia To', 'Alexander Rajasekaran', 'Liam Mackay'],
   },
   {
     title: 'Garden Sensor Array',
@@ -424,6 +433,7 @@ export const projects: Project[] = [
     tags: ['iot', 'sensors', 'community', 'hardware', 'raspberry-pi', 'embedded','bluetooth'],
     semester: 'Fall 2023',
     slug: 'garden-sensor-array',
+    members: ['Alexander Korsunsky', 'Sam GL', 'Regina Oda', 'Giorgio Tatarelli', 'Gabriel Sta Ana', 'Jimson Whiskeyman'],
   },
   {
     title: 'Lomo',
@@ -435,6 +445,7 @@ export const projects: Project[] = [
     tags: ['gaming', 'geolocation', 'social','pwa','laravel'],
     semester: 'Fall 2023',
     slug: 'lomo',
+    members: ['Jonathan Altenburg', 'Andy Olshanky', 'Emma Pincus', 'Ziyi Ke', 'Carla Delima', 'Alan Uthuppan', 'Jennifer Lieu'],
   },
   {
     title: 'Code Review Chatbot',
@@ -445,6 +456,7 @@ export const projects: Project[] = [
     tags: ['ai', 'code-quality', 'vscode-extension', 'education','laravel'],
     semester: 'Fall 2023',
     slug: 'code-review-chatbot',
+    members: ['Jason Lee', 'Thomas Rau', 'Kroos Xiang', 'Joshua Deland', 'Patrick Brady', 'Joseph Shiller', 'Domenic Malinsky'],
   },
   {
     title: 'ARPetPals',
@@ -455,6 +467,7 @@ export const projects: Project[] = [
     tags: ['virtual-pet','ar', 'mobile', 'health', 'fitness', 'unity','gamification'],
     semester: 'Fall 2023',
     slug: 'ar-pet-pals',
+    members: ['Son Tran', 'Karl James Gray', 'Youfei Li', 'Alex Mailo', 'Hy D Nguyen', "Dario George D'Aguanno", 'Anya Tewari'],
   },
   {
     title: 'Study Buddy',
@@ -466,6 +479,7 @@ export const projects: Project[] = [
     tags: ['virtual-pet','education', 'gamification', 'pwa', 'canvas-lms','react','django','sqlite'],
     semester: 'Spring 2023',
     slug: 'study-buddy',
+    members: ['Mary Clay', 'Christine Cho', 'Alexander Russakoff', 'Katrina Janeczko', 'Harrison Fedor', 'Jay Newman'],
   },
   {
     title: 'TUTraffic',
@@ -478,6 +492,7 @@ export const projects: Project[] = [
     semester: 'Spring 2023',
     // useDocsAsPreview: true,
     slug: 'tu-traffic',
+    members: ['Ethan Hopkins', 'Adam Wong', 'Logan Bennett', 'Isaac Ferguson', 'Raymond Chen', 'Brian Rangel', 'Maguire Qvale', 'Jason Michel'],
   },
   {
     title: 'Robocontrol',
@@ -499,6 +514,7 @@ export const projects: Project[] = [
     tags: ['iot', 'mobile', 'safety', 'bluetooth', 'embedded','hardware'],
     semester: 'Spring 2023',
     slug: 'vehicle-collision-detection',
+    members: ['Evan Noyes', 'Austin Foster', 'Thanh Nguyen', 'Bradley Dinger', 'Arif Ayarci', 'Nathan Adiam', 'Justice Chang'],
     useDocsAsPreview: true
   },
   {
@@ -510,6 +526,7 @@ export const projects: Project[] = [
     tags: ['discordBot', 'chatbot', 'github', 'jira', 'collaboration', 'devops'],
     semester: 'Fall 2022',
     slug: 'collabybot',
+    members: ['Sofia Drachuk', 'Dan Kalyniy', 'Nahara Johnson', 'Marshall Walsh'],
   },
   {
     title: 'Sokroban',
@@ -521,6 +538,7 @@ export const projects: Project[] = [
     tags: ['game', 'puzzle', 'multiplayer', 'unity', 'webgl'],
     semester: 'Fall 2022',
     slug: 'sokroban',
+    members: ['Arthur Kozhevnik', 'Roberto Nano', 'Felix Rabinovich', 'Riddhi Patel'],
   },
 
 ];

--- a/documentation/src/pages/showcase/_components/ShowcaseCard/index.tsx
+++ b/documentation/src/pages/showcase/_components/ShowcaseCard/index.tsx
@@ -119,6 +119,9 @@ function ShowcaseCard({user, contributorsColumns = 4}: {user: User; contributors
         className={clsx('card__image', styles.showcaseCardImage)}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}>
+        {user.semester && (
+          <span className={styles.semesterChipOverlay}>{user.semester}</span>
+        )}
         {isHovered && youtubeVideoId ? (
           <iframe
             src={`https://www.youtube.com/embed/${youtubeVideoId}?autoplay=1&mute=1${

--- a/documentation/src/pages/showcase/_components/ShowcaseCard/index.tsx
+++ b/documentation/src/pages/showcase/_components/ShowcaseCard/index.tsx
@@ -97,11 +97,17 @@ function parseYoutubeUrl(url: string): {
   return {videoId, startTime};
 }
 
+function getHighlightLabels(user: User): string[] {
+  return Array.isArray(user.highlights) ? user.highlights.slice(0, 3) : [];
+}
+
 function ShowcaseCard({user, contributorsColumns = 4}: {user: User; contributorsColumns?: number}) {
   const image = getCardImage(user);
   const [expanded, setExpanded] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const {videoId: youtubeVideoId, startTime} = parseYoutubeUrl(user.demo);
+  const members = user.members?.filter(Boolean) ?? [];
+  const highlightLabels = getHighlightLabels(user);
 
   const MAX = 150;
   const desc = user.description ?? '';
@@ -286,10 +292,21 @@ function ShowcaseCard({user, contributorsColumns = 4}: {user: User; contributors
             </Link>
           )}
         </div>
-        {/* Contributors wrapped in a list item for valid HTML and layout control */}
-        {/*<li className={styles.contributorsItem}>*/}
-          {user.source && <Contributors githubURL={user.source} columns={7} />}
-        {/*</li>*/}
+        {highlightLabels.length > 0 && (
+          <p className={styles.highlightSummary}>
+            {highlightLabels.join(' · ')}
+          </p>
+        )}
+        {(user.source || members.length > 0) && (
+          <div className={styles.contributorBlock}>
+            {user.source && (
+              <Contributors githubURL={user.source} columns={contributorsColumns} />
+            )}
+            {members.length > 0 && (
+              <p className={styles.memberList}>{members.join(', ')}</p>
+            )}
+          </div>
+        )}
         <p className={styles.showcaseCardBody}>
           {isLong ? (
             <>

--- a/documentation/src/pages/showcase/_components/ShowcaseCard/styles.module.css
+++ b/documentation/src/pages/showcase/_components/ShowcaseCard/styles.module.css
@@ -51,6 +51,13 @@
   backdrop-filter: blur(8px);
 }
 
+[data-theme='dark'] .semesterChipOverlay {
+  background: rgba(17, 24, 39, 0.88);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.38);
+}
+
 .showcaseCardTitle a {
   text-decoration: none;
   background: linear-gradient(

--- a/documentation/src/pages/showcase/_components/ShowcaseCard/styles.module.css
+++ b/documentation/src/pages/showcase/_components/ShowcaseCard/styles.module.css
@@ -101,6 +101,24 @@
   flex: 1 1 auto; /* fill remaining space inside card body */
 }
 
+.highlightSummary {
+  margin: -0.1rem 0 0.85rem;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.84rem;
+  font-weight: 600;
+}
+
+.contributorBlock {
+  margin-bottom: 0.85rem;
+}
+
+.memberList {
+  margin: 0.35rem 0 0;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
 .cardFooter {
   display: flex;
   flex-wrap: wrap;

--- a/documentation/src/pages/showcase/_components/ShowcaseCard/styles.module.css
+++ b/documentation/src/pages/showcase/_components/ShowcaseCard/styles.module.css
@@ -6,6 +6,7 @@
  */
 
 .showcaseCardImage {
+  position: relative;
   overflow: hidden;
   height: 150px;
   border-bottom: 2px solid var(--ifm-color-emphasis-200);
@@ -26,6 +27,30 @@
   align-items: center;
 }
 
+.semesterChipOverlay {
+  position: absolute;
+  top: 0.7rem;
+  right: 0.7rem;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.22rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid color-mix(
+    in srgb,
+    var(--ifm-color-primary) 16%,
+    var(--ifm-color-emphasis-300) 84%
+  );
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.1);
+  backdrop-filter: blur(8px);
+}
+
 .showcaseCardTitle a {
   text-decoration: none;
   background: linear-gradient(
@@ -44,7 +69,7 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  margin-left: 0.5rem;
+  margin-left: auto;
   padding: 0.25rem;
   opacity: 0;
   transition: opacity 0.2s ease-in-out;
@@ -278,6 +303,8 @@
 .youtubeEmbed {
   width: 100%;
   height: 100%;
+  position: relative;
+  z-index: 1;
 }
 
 /* Ensure contributors block sits on its own row beneath tag pills */

--- a/documentation/src/pages/showcase/_components/ShowcaseCards/index.tsx
+++ b/documentation/src/pages/showcase/_components/ShowcaseCards/index.tsx
@@ -5,24 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
-import {sortedUsers, type User} from '@site/src/data/showcase';
+import {type User} from '@site/src/data/showcase';
 import Heading from '@theme/Heading';
-import FavoriteIcon from '../FavoriteIcon';
 import ShowcaseCard from '../ShowcaseCard';
-import {useFilteredAndSortedUsers} from '../../_utils';
+import {semesterToCohort, useFilteredAndSortedUsers} from '../../_utils';
 
 import styles from './styles.module.css';
-
-const favoriteUsers = sortedUsers.filter((user) =>
-  user.tags.includes('favorite'),
-);
-
-const otherUsers = sortedUsers.filter(
-  (user) => !user.tags.includes('favorite'),
-);
 
 function HeadingNoResult() {
   return (
@@ -32,33 +22,74 @@ function HeadingNoResult() {
   );
 }
 
-function HeadingFavorites() {
-  return (
-    <Heading as="h2" className={styles.headingFavorites}>
-      <Translate id="showcase.favoritesList.title">Our favorites</Translate>
-      <FavoriteIcon size="large" style={{marginLeft: '1rem'}} />
-    </Heading>
-  );
+function semesterSortKey(semester?: string) {
+  if (!semester) return Infinity;
+  const [seasonRaw = '', yearRaw = '0'] = semester.split(/\s+/);
+  const year = Number.parseInt(yearRaw, 10);
+  const season = seasonRaw.toLowerCase();
+  const seasonOrder: Record<string, number> = {
+    fall: 0,
+    spring: 1,
+    summer: 2,
+    winter: 3,
+  };
+  return ((Number.isFinite(year) ? year : 0) * 10) + (seasonOrder[season] ?? 9);
 }
 
-function HeadingAllSites() {
-  return (
-    <Heading as="h2">
-      <Translate id="showcase.usersList.allUsers">All sites</Translate>
-    </Heading>
-  );
+function getCohortGroups(items: User[]) {
+  const groups = new Map<string, User[]>();
+  items.forEach((item) => {
+    const cohort = semesterToCohort(item.semester) ?? 'Archive';
+    const group = groups.get(cohort);
+    if (group) {
+      group.push(item);
+    } else {
+      groups.set(cohort, [item]);
+    }
+  });
+
+  return [...groups.entries()].sort(([cohortA], [cohortB]) => {
+    if (cohortA === 'Archive') return 1;
+    if (cohortB === 'Archive') return -1;
+    return Number(cohortB) - Number(cohortA);
+  });
 }
 
-function CardList({heading, items}: {heading?: ReactNode; items: User[]}) {
+function CohortSection({cohort, items}: {cohort: string; items: User[]}) {
+  const semesters = Array.from(
+    new Set(items.map((item) => item.semester).filter(Boolean)),
+  ).sort((a, b) => semesterSortKey(a) - semesterSortKey(b)) as string[];
+
   return (
-    <div className="container">
-      {heading}
-      <ul className={clsx('clean-list', styles.cardList)}>
-        {items.map((item) => (
-          <ShowcaseCard key={item.title} user={item} contributorsColumns={4} />
-        ))}
-      </ul>
-    </div>
+    <section
+      id={`showcase-cohort-${cohort}`}
+      className={styles.yearSection}
+      aria-labelledby={`showcase-cohort-heading-${cohort}`}>
+      <div className={clsx('container', styles.yearSectionLayout)}>
+        <div className={styles.yearSectionHeader}>
+          <Heading as="h2" id={`showcase-cohort-heading-${cohort}`} className={styles.yearSectionTitle}>
+            {cohort}
+          </Heading>
+          <p className={styles.projectCount}>{items.length} project{items.length === 1 ? '' : 's'}</p>
+          {semesters.length > 0 && (
+            <ul className={clsx('clean-list', styles.semesterList)}>
+              {semesters.map((semester) => (
+                <li key={semester} className={styles.semesterPill}>
+                  {semester}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div>
+          <ul className={clsx('clean-list', styles.cardList)}>
+            {items.map((item) => (
+              <ShowcaseCard key={item.title} user={item} contributorsColumns={5} />
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -79,21 +110,22 @@ export default function ShowcaseCards() {
     return <NoResultSection />;
   }
 
+  const groupedUsers = getCohortGroups(filteredUsers);
+
   return (
     <section className="margin-top--lg margin-bottom--xl">
-      {filteredUsers.length === sortedUsers.length ? (
-        <>
-          {/*<div className={styles.showcaseFavorite}>*/}
-          {/*  <CardList heading={<HeadingFavorites />} items={favoriteUsers} />*/}
-          {/*</div>*/}
-          <div className="margin-top--lg">
-            <CardList heading={<HeadingAllSites />} items={otherUsers} />
-          </div>
-        </>
-      ) : (
-        <CardList items={filteredUsers} />
-      )}
-        <p style={{textAlign: 'center', padding:40}}>Contributor Icons Made with<a href={"https://contrib.rocks"}> contrib.rocks</a>.<br/> This page's design borrows heavily from <a href={'https://docusaurus.io/showcase'}>Facebook's Docusaurus Site Showcase</a> Page.</p>
+      {groupedUsers.map(([cohort, items]) => (
+        <CohortSection key={cohort} cohort={cohort} items={items} />
+      ))}
+      <p style={{textAlign: 'center', padding: 40}}>
+        Contributor Icons Made with
+        <a href={'https://contrib.rocks'}> contrib.rocks</a>.
+        <br />
+        This page&apos;s design borrows heavily from
+        <a href={'https://docusaurus.io/showcase'}> Facebook&apos;s Docusaurus Site Showcase</a>
+        {' '}
+        Page.
+      </p>
     </section>
   );
 }

--- a/documentation/src/pages/showcase/_components/ShowcaseCards/index.tsx
+++ b/documentation/src/pages/showcase/_components/ShowcaseCards/index.tsx
@@ -10,7 +10,7 @@ import Translate from '@docusaurus/Translate';
 import {type User} from '@site/src/data/showcase';
 import Heading from '@theme/Heading';
 import ShowcaseCard from '../ShowcaseCard';
-import {semesterToCohort, useFilteredAndSortedUsers} from '../../_utils';
+import {cohortToAcademicYearLabel, semesterToCohort, useFilteredAndSortedUsers} from '../../_utils';
 
 import styles from './styles.module.css';
 
@@ -68,18 +68,9 @@ function CohortSection({cohort, items}: {cohort: string; items: User[]}) {
       <div className={clsx('container', styles.yearSectionLayout)}>
         <div className={styles.yearSectionHeader}>
           <Heading as="h2" id={`showcase-cohort-heading-${cohort}`} className={styles.yearSectionTitle}>
-            {cohort}
+            {cohortToAcademicYearLabel(cohort)}
           </Heading>
           <p className={styles.projectCount}>{items.length} project{items.length === 1 ? '' : 's'}</p>
-          {semesters.length > 0 && (
-            <ul className={clsx('clean-list', styles.semesterList)}>
-              {semesters.map((semester) => (
-                <li key={semester} className={styles.semesterPill}>
-                  {semester}
-                </li>
-              ))}
-            </ul>
-          )}
         </div>
         <div>
           <ul className={clsx('clean-list', styles.cardList)}>

--- a/documentation/src/pages/showcase/_components/ShowcaseCards/styles.module.css
+++ b/documentation/src/pages/showcase/_components/ShowcaseCards/styles.module.css
@@ -11,17 +11,54 @@
   gap: 24px;
 }
 
-.showcaseFavorite {
-  padding-top: 2rem;
-  padding-bottom: 2rem;
-  background-color: #f6fdfd;
+.yearSection {
+  margin-top: 1.75rem;
 }
 
-html[data-theme='dark'] .showcaseFavorite {
-  background-color: #232525;
+.yearSectionLayout {
+  display: grid;
+  grid-template-columns: minmax(150px, 210px) minmax(0, 1fr);
+  align-items: start;
+  gap: 1rem;
 }
 
-.headingFavorites {
+.yearSectionHeader {
+  position: sticky;
+  top: 5.75rem;
+  padding-top: 0.2rem;
+}
+
+.yearSectionTitle {
+  margin-bottom: 0.45rem;
+}
+
+.projectCount {
+  margin: 0 0 0.8rem;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.95rem;
+}
+
+.semesterList {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.semesterPill {
+  padding: 0.26rem 0.62rem;
+  border-radius: 999px;
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+@media (max-width: 768px) {
+  .yearSectionLayout {
+    grid-template-columns: 1fr;
+  }
+
+  .yearSectionHeader {
+    position: static;
+  }
 }

--- a/documentation/src/pages/showcase/_components/ShowcaseFilters/index.tsx
+++ b/documentation/src/pages/showcase/_components/ShowcaseFilters/index.tsx
@@ -299,7 +299,14 @@ function CohortFilters() {
 
   return (
     <div className={styles.cohortFilters}>
-      <span className={styles.cohortLabel}>Academic year</span>
+      <span className={styles.cohortLabel}>
+        <Translate
+            id="showcase.filters.cohortLabel"
+            description={'Label for a cohort filter button, where the button label is the academic year. Example: "Filter by academic year 2022-2023"'}
+        >
+          Academic Year
+        </Translate>
+      </span>
       <ul className={clsx('clean-list', styles.cohortList)}>
         {cohortOptions.map(({label, count}) => {
           const selected = cohort === label;

--- a/documentation/src/pages/showcase/_components/ShowcaseFilters/index.tsx
+++ b/documentation/src/pages/showcase/_components/ShowcaseFilters/index.tsx
@@ -16,6 +16,7 @@ import ShowcaseTagSelect from '../ShowcaseTagSelect';
 import OperatorButton from '../OperatorButton';
 import ClearAllButton from '../ClearAllButton';
 import {
+  cohortToAcademicYearLabel,
   semesterToCohort,
   useCohort,
   useFilteredUsers,
@@ -309,7 +310,7 @@ function CohortFilters() {
                 className={clsx(styles.cohortButton, selected && styles.cohortButtonActive)}
                 aria-pressed={selected}
                 onClick={() => setCohort(selected ? null : label)}>
-                <span>{label}</span>
+                <span>{cohortToAcademicYearLabel(label)}</span>
                 <span className={styles.cohortCount}>{count}</span>
               </button>
             </li>

--- a/documentation/src/pages/showcase/_components/ShowcaseFilters/index.tsx
+++ b/documentation/src/pages/showcase/_components/ShowcaseFilters/index.tsx
@@ -15,8 +15,14 @@ import Heading from '@theme/Heading';
 import ShowcaseTagSelect from '../ShowcaseTagSelect';
 import OperatorButton from '../OperatorButton';
 import ClearAllButton from '../ClearAllButton';
-import {useFilteredUsers, useSiteCountPlural, useSemester, useUsersForCounts} from '../../_utils';
-import {sortedUsers} from '@site/src/data/showcase';
+import {
+  semesterToCohort,
+  useCohort,
+  useFilteredUsers,
+  useSiteCountPlural,
+  useUsersForCohortCounts,
+  useUsersForCounts,
+} from '../../_utils';
 
 import styles from './styles.module.css';
 
@@ -204,30 +210,6 @@ function HeadingText() {
 }
 
 function HeadingButtons() {
-  const [semester, setSemester] = useSemester();
-
-  // Build semester options from sortedUsers (unique, non-empty)
-  const semesterOptions = useMemo(() => {
-    const set = new Set<string>();
-    for (const u of sortedUsers) {
-      if (u.semester) set.add(u.semester);
-    }
-    // Convert to array and sort using a simple comparator that prefers newer semesters
-    const arr = Array.from(set);
-    const seasonOrder: Record<string, number> = { spring: 0, summer: 1, fall: 2, winter: 3 };
-    arr.sort((a, b) => {
-      const pa = a.split(/\s+/);
-      const pb = b.split(/\s+/);
-      const ya = parseInt(pa[1] || '0', 10);
-      const yb = parseInt(pb[1] || '0', 10);
-      if (ya !== yb) return yb - ya;
-      const sa = seasonOrder[(pa[0] || '').toLowerCase()] ?? 4;
-      const sb = seasonOrder[(pb[0] || '').toLowerCase()] ?? 4;
-      return sb - sa;
-    });
-    return arr;
-  }, []);
-
   // Smooth-scroll to glossary
   function goToGlossary() {
     try {
@@ -284,20 +266,6 @@ function HeadingButtons() {
   return (
     <div className={styles.headingButtons} style={{alignItems: 'center'}}>
       <OperatorButton />
-      <div style={{display: 'flex', alignItems: 'center'}}>
-        <label htmlFor="semester-select" style={{marginRight: 8, fontSize: '0.9rem'}}>Semester</label>
-        <select
-          id="semester-select"
-          value={semester ?? ''}
-          onChange={(e) => setSemester(e.target.value || null)}
-          className={styles.semesterSelect}
-        >
-          <option value="">All</option>
-          {semesterOptions.map((s) => (
-            <option key={s} value={s}>{s}</option>
-          ))}
-        </select>
-      </div>
       <button
         type="button"
         className={styles.glossaryButton}
@@ -309,6 +277,49 @@ function HeadingButtons() {
         {translate({id: 'showcase.filters.gotoGlossaryShort', message: 'Glossary'})}
       </button>
       <ClearAllButton />
+    </div>
+  );
+}
+
+function CohortFilters() {
+  const [cohort, setCohort] = useCohort();
+  const usersForCounts = useUsersForCohortCounts();
+  const cohortOptions = useMemo(() => {
+    const counts = new Map<string, number>();
+    usersForCounts.forEach((user) => {
+      const label = semesterToCohort(user.semester);
+      if (!label) return;
+      counts.set(label, (counts.get(label) ?? 0) + 1);
+    });
+    return [...counts.entries()]
+      .sort(([a], [b]) => Number(b) - Number(a))
+      .map(([label, count]) => ({label, count}));
+  }, [usersForCounts]);
+
+  if (cohortOptions.length <= 1) {
+    return null;
+  }
+
+  return (
+    <div className={styles.cohortFilters}>
+      <span className={styles.cohortLabel}>Academic year</span>
+      <ul className={clsx('clean-list', styles.cohortList)}>
+        {cohortOptions.map(({label, count}) => {
+          const selected = cohort === label;
+          return (
+            <li key={label}>
+              <button
+                type="button"
+                className={clsx(styles.cohortButton, selected && styles.cohortButtonActive)}
+                aria-pressed={selected}
+                onClick={() => setCohort(selected ? null : label)}>
+                <span>{label}</span>
+                <span className={styles.cohortCount}>{count}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }
@@ -326,6 +337,7 @@ export default function ShowcaseFilters(): ReactNode {
   return (
     <section className="container margin-top--l margin-bottom--lg">
       <HeadingRow />
+      <CohortFilters />
       <ShowcaseTagList />
     </section>
   );

--- a/documentation/src/pages/showcase/_components/ShowcaseFilters/index.tsx
+++ b/documentation/src/pages/showcase/_components/ShowcaseFilters/index.tsx
@@ -273,7 +273,7 @@ function GlossaryShortcut() {
       aria-controls="showcase-glossary"
       aria-label={translate({id: 'showcase.filters.gotoGlossary', message: 'Go to glossary'})}
     >
-      {translate({id: 'showcase.filters.gotoGlossaryContext', message: 'Filter glossary'})}
+      {translate({id: 'showcase.filters.gotoGlossaryContext', message: 'View filter glossary'})}
     </button>
   );
 }

--- a/documentation/src/pages/showcase/_components/ShowcaseFilters/index.tsx
+++ b/documentation/src/pages/showcase/_components/ShowcaseFilters/index.tsx
@@ -210,43 +210,44 @@ function HeadingText() {
 }
 
 function HeadingButtons() {
-  // Smooth-scroll to glossary
+  return (
+    <div className={styles.headingButtons} style={{alignItems: 'center'}}>
+      <OperatorButton />
+      <ClearAllButton />
+    </div>
+  );
+}
+
+function GlossaryShortcut() {
   function goToGlossary() {
     try {
-      // Ask the page to load the glossary (Showcase page listens for this event)
       window.dispatchEvent(new Event('showcase:loadGlossary'));
 
       const scrollTo = () => {
         const el = document.getElementById('showcase-glossary');
-        if (el) {
-          el.scrollIntoView({behavior: 'smooth', block: 'start'});
-          // After scrolling, place keyboard focus on the glossary for accessibility
-          // Use a short timeout to avoid fighting the smooth scroll animation
-          window.setTimeout(() => {
-            try {
-              (el as HTMLElement).focus();
-            } catch (e) {
-              // ignore if focus isn't supported in the environment
-            }
-          }, 400);
-          return true;
+        if (!el) {
+          return false;
         }
-        return false;
+        el.scrollIntoView({behavior: 'smooth', block: 'start'});
+        window.setTimeout(() => {
+          try {
+            (el as HTMLElement).focus();
+          } catch (e) {
+            // ignore if focus isn't supported in the environment
+          }
+        }, 400);
+        return true;
       };
 
-      // If it's already present, scroll immediately
       if (scrollTo()) return;
 
-      // Otherwise poll for the element for up to ~4 seconds
       let attempts = 0;
-      const maxAttempts = 40; // 40 * 100ms = 4000ms
-      const intervalMs = 100;
       const timer = window.setInterval(() => {
         attempts += 1;
-        if (scrollTo() || attempts >= maxAttempts) {
+        if (scrollTo() || attempts >= 40) {
           clearInterval(timer);
         }
-      }, intervalMs);
+      }, 100);
     } catch (e) {
       // ignore in SSR or restricted environments
     }
@@ -257,27 +258,22 @@ function HeadingButtons() {
   function prefetchGlossary() {
     if (glossaryPrefetched) return;
     glossaryPrefetched = true;
-    // Dynamic import to warm the chunk (path relative to this file)
     import('../ShowcaseGlossary').catch(() => {
       // ignore failures; load will be attempted again when requested
     });
   }
 
   return (
-    <div className={styles.headingButtons} style={{alignItems: 'center'}}>
-      <OperatorButton />
-      <button
-        type="button"
-        className={styles.glossaryButton}
-        onClick={goToGlossary}
-        onMouseEnter={prefetchGlossary}
-        aria-controls="showcase-glossary"
-        aria-label={translate({id: 'showcase.filters.gotoGlossary', message: 'Go to glossary'})}
-      >
-        {translate({id: 'showcase.filters.gotoGlossaryShort', message: 'Glossary'})}
-      </button>
-      <ClearAllButton />
-    </div>
+    <button
+      type="button"
+      className={styles.glossaryButton}
+      onClick={goToGlossary}
+      onMouseEnter={prefetchGlossary}
+      aria-controls="showcase-glossary"
+      aria-label={translate({id: 'showcase.filters.gotoGlossary', message: 'Go to glossary'})}
+    >
+      {translate({id: 'showcase.filters.gotoGlossaryContext', message: 'Filter glossary'})}
+    </button>
   );
 }
 
@@ -339,6 +335,9 @@ export default function ShowcaseFilters(): ReactNode {
       <HeadingRow />
       <CohortFilters />
       <ShowcaseTagList />
+      <div className={styles.filterFooter}>
+        <GlossaryShortcut />
+      </div>
     </section>
   );
 }

--- a/documentation/src/pages/showcase/_components/ShowcaseFilters/styles.module.css
+++ b/documentation/src/pages/showcase/_components/ShowcaseFilters/styles.module.css
@@ -38,9 +38,9 @@
 
 .cohortFilters {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.85rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
   margin-bottom: 1rem;
 }
 
@@ -57,6 +57,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.6rem;
+  width: 100%;
 }
 
 .cohortButton {
@@ -70,11 +71,18 @@
   color: var(--ifm-font-color-base);
   cursor: pointer;
   font-weight: 600;
+  transition:
+    background-color var(--ifm-transition-fast) ease,
+    border-color var(--ifm-transition-fast) ease,
+    color var(--ifm-transition-fast) ease,
+    box-shadow var(--ifm-transition-fast) ease;
 }
 
 .cohortButton:hover {
   border-color: var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
+  background: var(--ifm-color-primary);
+  color: var(--ifm-color-white);
+  box-shadow: 0 0 0 1px var(--ifm-color-primary);
 }
 
 .cohortButtonActive {
@@ -83,9 +91,19 @@
   color: var(--ifm-color-primary-darkest);
 }
 
+.cohortButtonActive:hover {
+  background: var(--ifm-color-primary);
+  color: var(--ifm-color-white);
+}
+
 .cohortCount {
   color: var(--ifm-color-emphasis-600);
   font-size: 0.82rem;
+}
+
+.cohortButton:hover .cohortCount,
+.cohortButtonActive:hover .cohortCount {
+  color: currentColor;
 }
 
 .tagList {
@@ -147,10 +165,18 @@
   font-weight: 600;
   border-radius: 999px;
   cursor: pointer;
+  transition:
+    background-color var(--ifm-transition-fast) ease,
+    border-color var(--ifm-transition-fast) ease,
+    color var(--ifm-transition-fast) ease,
+    box-shadow var(--ifm-transition-fast) ease;
 }
 
 .glossaryButton:hover {
-  background: color-mix(in srgb, var(--ifm-color-primary) 8%, white 92%);
+  background: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-white);
+  box-shadow: 0 0 0 1px var(--ifm-color-primary);
 }
 
 .glossaryButton:focus {

--- a/documentation/src/pages/showcase/_components/ShowcaseFilters/styles.module.css
+++ b/documentation/src/pages/showcase/_components/ShowcaseFilters/styles.module.css
@@ -36,6 +36,57 @@
   margin-top: 0.5rem;
 }
 
+.cohortFilters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.85rem;
+  margin-bottom: 1rem;
+}
+
+.cohortLabel {
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.cohortList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.cohortButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.9rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 999px;
+  background: var(--ifm-card-background-color);
+  color: var(--ifm-font-color-base);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.cohortButton:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+.cohortButtonActive {
+  border-color: var(--ifm-color-primary);
+  background: color-mix(in srgb, var(--ifm-color-primary) 10%, var(--ifm-card-background-color) 90%);
+  color: var(--ifm-color-primary-darkest);
+}
+
+.cohortCount {
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.82rem;
+}
+
 .tagList {
   display: flex;
   align-items: center;
@@ -80,14 +131,6 @@
   outline-offset: 2px;
 }
 
-.semesterSelect {
-  font-size: 0.9rem;
-  padding: 6px 8px;
-  border-radius: 4px;
-  border: 1px solid rgba(0, 0, 0, 0.12);
-  background: var(--ifm-background-color, #fff);
-}
-
 .glossaryButton {
   background: var(--ifm-color-primary, #0d47a1);
   color: var(--ifm-color-white, #fff);
@@ -105,4 +148,20 @@
 .glossaryButton:focus {
   outline: 2px solid rgba(13, 71, 161, 0.2);
   outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .headingRow {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .headingButtons {
+    justify-content: flex-start;
+  }
+
+  .headingButtons > * {
+    margin-left: 0;
+    margin-right: 8px;
+  }
 }

--- a/documentation/src/pages/showcase/_components/ShowcaseFilters/styles.module.css
+++ b/documentation/src/pages/showcase/_components/ShowcaseFilters/styles.module.css
@@ -46,10 +46,11 @@
 
 .cohortLabel {
   color: var(--ifm-color-emphasis-700);
-  font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: normal;
+  text-transform: none;
 }
 
 .cohortList {
@@ -112,6 +113,12 @@
   justify-content: flex-start;
 }
 
+.filterFooter {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.75rem;
+}
+
 .showMoreButton {
   background: transparent;
   border: none;
@@ -132,17 +139,18 @@
 }
 
 .glossaryButton {
-  background: var(--ifm-color-primary, #0d47a1);
-  color: var(--ifm-color-white, #fff);
-  border: none;
-  padding: 6px 10px;
+  background: transparent;
+  color: var(--ifm-color-primary, #0d47a1);
+  border: 1px solid color-mix(in srgb, var(--ifm-color-primary) 22%, white 78%);
+  padding: 0.5rem 0.9rem;
   font-size: 0.9rem;
-  border-radius: 4px;
+  font-weight: 600;
+  border-radius: 999px;
   cursor: pointer;
 }
 
 .glossaryButton:hover {
-  opacity: 0.95;
+  background: color-mix(in srgb, var(--ifm-color-primary) 8%, white 92%);
 }
 
 .glossaryButton:focus {
@@ -163,5 +171,9 @@
   .headingButtons > * {
     margin-left: 0;
     margin-right: 8px;
+  }
+
+  .filterFooter {
+    justify-content: flex-start;
   }
 }

--- a/documentation/src/pages/showcase/_components/ShowcaseGlossary/index.tsx
+++ b/documentation/src/pages/showcase/_components/ShowcaseGlossary/index.tsx
@@ -67,7 +67,7 @@ export default function ShowcaseGlossary(): ReactNode {
   const allTags: TagType[] = [...categoryTags.slice(0, 24), ...languageTags] as TagType[];
 
   // Batch loading configuration
-  const BATCH_SIZE = 9; // number of items to load per batch
+  const BATCH_SIZE = 6; // number of items to load per batch
 
   const [visibleCount, setVisibleCount] = useState<number>(0);
   const [loadedOnce, setLoadedOnce] = useState(false);

--- a/documentation/src/pages/showcase/_utils.tsx
+++ b/documentation/src/pages/showcase/_utils.tsx
@@ -22,10 +22,6 @@ export function useTags() {
   return useQueryStringList('tags');
 }
 
-export function useSemester() {
-  return useQueryString('semester');
-}
-
 export function useCohort() {
   return useQueryString('cohort');
 }
@@ -47,14 +43,12 @@ function filterUsers({
   tags,
   operator,
   searchName,
-  semester,
   cohort,
 }: {
   users: User[];
   tags: TagType[];
   operator: Operator;
   searchName: string | null;
-  semester?: string | null;
   cohort?: string | null;
 }) {
   if (searchName) {
@@ -67,9 +61,6 @@ function filterUsers({
         .toLowerCase();
       return searchableFields.includes(normalizedSearch);
     });
-  }
-  if (semester) {
-    users = users.filter((user) => user.semester === semester);
   }
   if (cohort) {
     users = users.filter((user) => semesterToCohort(user.semester) === cohort);
@@ -92,7 +83,6 @@ export function useFilteredUsers() {
   const [tags] = useTags();
   const [searchName] = useSearchName();
   const [operator] = useOperator();
-  const [semester] = useSemester();
   const [cohort] = useCohort();
   return useMemo(
     () =>
@@ -101,18 +91,16 @@ export function useFilteredUsers() {
         tags: tags as TagType[],
         operator,
         searchName,
-        semester,
         cohort,
       }),
-    [tags, operator, searchName, semester, cohort],
+    [tags, operator, searchName, cohort],
   );
 }
 
-// Return users filtered by the current searchName/semester but ignoring tag selection.
+// Return users filtered by the current searchName/cohort but ignoring tag selection.
 // This is useful to compute per-tag counts without circular dependency on current tag selection.
 export function useUsersForCounts() {
   const [searchName] = useSearchName();
-  const [semester] = useSemester();
   const [cohort] = useCohort();
   return useMemo(
     () =>
@@ -121,10 +109,9 @@ export function useUsersForCounts() {
         tags: [],
         operator: 'OR',
         searchName,
-        semester,
         cohort,
       }),
-    [searchName, semester, cohort],
+    [searchName, cohort],
   );
 }
 
@@ -158,6 +145,13 @@ export function semesterToCohort(sem?: string | null) {
   const parsed = parseSemester(sem);
   if (!parsed) return null;
   return String(parsed.season === 'fall' ? parsed.year + 1 : parsed.year);
+}
+
+export function cohortToAcademicYearLabel(cohort?: string | null) {
+  if (!cohort) return '';
+  const endYear = Number.parseInt(cohort, 10);
+  if (!Number.isFinite(endYear)) return cohort;
+  return `${endYear - 1} - ${endYear}`;
 }
 
 // Helper: compute a sortable numeric key from semester strings like "Spring 2025"

--- a/documentation/src/pages/showcase/_utils.tsx
+++ b/documentation/src/pages/showcase/_utils.tsx
@@ -22,9 +22,12 @@ export function useTags() {
   return useQueryStringList('tags');
 }
 
-// Semester hook (single-value): store selected semester in the query string
 export function useSemester() {
   return useQueryString('semester');
+}
+
+export function useCohort() {
+  return useQueryString('cohort');
 }
 
 type Operator = 'OR' | 'AND';
@@ -45,21 +48,31 @@ function filterUsers({
   operator,
   searchName,
   semester,
+  cohort,
 }: {
   users: User[];
   tags: TagType[];
   operator: Operator;
   searchName: string | null;
   semester?: string | null;
+  cohort?: string | null;
 }) {
   if (searchName) {
+    const normalizedSearch = searchName.toLowerCase();
     // eslint-disable-next-line no-param-reassign
-    users = users.filter((user) =>
-      user.title.toLowerCase().includes(searchName.toLowerCase()),
-    );
+    users = users.filter((user) => {
+      const searchableFields = [user.title, ...(user.members ?? [])]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      return searchableFields.includes(normalizedSearch);
+    });
   }
   if (semester) {
     users = users.filter((user) => user.semester === semester);
+  }
+  if (cohort) {
+    users = users.filter((user) => semesterToCohort(user.semester) === cohort);
   }
   if (tags.length === 0) {
     return users;
@@ -80,6 +93,7 @@ export function useFilteredUsers() {
   const [searchName] = useSearchName();
   const [operator] = useOperator();
   const [semester] = useSemester();
+  const [cohort] = useCohort();
   return useMemo(
     () =>
       filterUsers({
@@ -88,8 +102,9 @@ export function useFilteredUsers() {
         operator,
         searchName,
         semester,
+        cohort,
       }),
-    [tags, operator, searchName, semester],
+    [tags, operator, searchName, semester, cohort],
   );
 }
 
@@ -98,6 +113,7 @@ export function useFilteredUsers() {
 export function useUsersForCounts() {
   const [searchName] = useSearchName();
   const [semester] = useSemester();
+  const [cohort] = useCohort();
   return useMemo(
     () =>
       filterUsers({
@@ -106,18 +122,49 @@ export function useUsersForCounts() {
         operator: 'OR',
         searchName,
         semester,
+        cohort,
       }),
-    [searchName, semester],
+    [searchName, semester, cohort],
   );
+}
+
+export function useUsersForCohortCounts() {
+  const [tags] = useTags();
+  const [searchName] = useSearchName();
+  const [operator] = useOperator();
+  return useMemo(
+    () =>
+      filterUsers({
+        users: sortedUsers,
+        tags: tags as TagType[],
+        operator,
+        searchName,
+      }),
+    [tags, operator, searchName],
+  );
+}
+
+function parseSemester(sem?: string | null) {
+  if (!sem) return null;
+  const parts = sem.split(/\s+/);
+  if (parts.length < 2) return null;
+  const season = parts[0].toLowerCase();
+  const year = parseInt(parts[1], 10);
+  if (!Number.isFinite(year)) return null;
+  return {season, year};
+}
+
+export function semesterToCohort(sem?: string | null) {
+  const parsed = parseSemester(sem);
+  if (!parsed) return null;
+  return String(parsed.season === 'fall' ? parsed.year + 1 : parsed.year);
 }
 
 // Helper: compute a sortable numeric key from semester strings like "Spring 2025"
 function semesterKey(sem?: string | null) {
-  if (!sem) return -Infinity;
-  const parts = sem.split(/\s+/);
-  if (parts.length < 2) return -Infinity;
-  const year = parseInt(parts[1], 10);
-  const season = parts[0].toLowerCase();
+  const parsed = parseSemester(sem);
+  if (!parsed) return -Infinity;
+  const {year, season} = parsed;
   const seasonOrder: Record<string, number> = {
     spring: 0,
     summer: 1,

--- a/documentation/static/slides/manifest.json
+++ b/documentation/static/slides/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-14T18:35:49.646Z",
+  "generatedAt": "2026-05-18T23:28:33.868Z",
   "groupBy": "week",
   "groupBasePath": "weeks",
   "totalSlides": 0,


### PR DESCRIPTION
## Summary
- Group showcase projects by academic year and keep year browsing inside the existing filter UI
- Simplify card metadata while adding clearer semester context and collaborator names for SEO
- Add optional highlights/members support to the showcase data model and schema
- Lazy-load the glossary entries in smaller batches to reduce initial page clutter

## Testing
- `yarn build` passed
- Verified the showcase page locally in the browser after the layout and card updates