### PR TITLE
Add technology accommodation pages for course tools

### DIFF
--- a/documentation/src/pages/technology-accommodations/docusaurus.mdx
+++ b/documentation/src/pages/technology-accommodations/docusaurus.mdx
@@ -1,0 +1,61 @@
+# Docusaurus Technology Accommodations
+
+This page summarizes accessibility support and accommodation considerations for Docusaurus in the capstone course. The sections below are also organized so the same information can be reused for university accessibility review questions when needed.
+
+## Product/Service Information
+
+### 1. Name of Product or Service
+Docusaurus
+
+### 2. Description and Usage
+Docusaurus is the documentation platform used in the course to publish project requirements, design materials, progress updates, technical references, and final project documentation as a version-controlled website. Students use it because it supports collaborative editing, source control integration, and deployment workflows that match modern software engineering practice.
+
+### 3. Product/Service Website
+- [Docusaurus](https://docusaurus.io/)
+
+### 4. How many individuals will use this product/service?
+More than 100 individuals in a semester. Capstone sections usually enroll about 20 to 25 students each, and there are typically 5 to 6 sections in a semester, which places expected usage above 100 users before including instructors and teaching assistants.
+
+### 5. How many individuals will be required to use this product/service for coursework or job function?
+More than 100 individuals are required to use Docusaurus for coursework or instructional support in a semester. Capstone sections usually enroll about 20 to 25 students each, and there are typically 5 to 6 sections in a semester, which places required usage above 100 users before including instructors and teaching assistants.
+
+### 6. Intended Audience
+Students, employees, and members of the public when course documentation is published on a public GitHub Pages site.
+
+### 7. Contract Expiration Date
+Docusaurus is open-source software. This field can generally be left blank unless the request is tied to a separate hosting or support contract.
+
+### 8. Are you submitting this request for yourself or on behalf of someone else?
+This is requestor-specific and should be completed by the instructor, staff member, or administrator submitting the form.
+
+## Exception Request Details
+
+### 9. Have you compared this product or service to others?
+Yes.
+
+### 10. Researched Alternatives and Why They Are Not Acceptable Replacements
+- Microsoft Word: Familiar to many students, but not well-suited to collaborative version control, continuous publishing, or maintaining software documentation in the same repository as the code.
+- Google Docs: Good for collaborative editing, but it does not provide the same repository-based workflow, deployment model, or long-term maintainability for technical documentation sites.
+- MkDocs: A reasonable documentation generator, but the course template, examples, and support materials are built around Docusaurus and its integration with the existing repository and publishing workflow.
+
+### 11. Reasonable Accommodations
+The use of Docusaurus does not change the learning objectives of the course. Reasonable accommodations may include:
+
+- Blind/Low Vision: Allow students to author content in accessible editors, use screen readers and browser zoom, and provide accessible templates that encourage headings, alt text, and semantic structure.
+- Deaf/Hard of Hearing: Provide captions or transcripts for any documentation tutorials and ensure instructions and feedback are available in written form.
+- Keyboard-Only Users: Support keyboard-based editing workflows in the chosen editor or browser and provide documentation templates that minimize complex interface interactions.
+- Speech-to-Text Users: Allow the use of speech recognition software to draft and edit Markdown documentation and related content.
+- Students with Limited or No Speech: Permit written participation through documentation commits, pull request comments, issue discussions, and written feedback instead of requiring verbal presentation alone.
+- Color Blindness: Do not rely solely on color in diagrams, callouts, screenshots, or charts embedded in the documentation site; require text labels and captions.
+- Cognitive or Learning Disabilities: Provide page templates, checklists, examples, milestone-based writing guidance, and additional time where appropriate.
+- Motor Disabilities: Permit assistive input devices and alternative authoring workflows, including editing in local tools or browser-based editors that work better with the student's assistive technology.
+
+### 12. Does the vendor have accessibility documentation?
+Limited public documentation exists, but a formal VPAT may not be available.
+
+### 13. Accessibility Documentation to Attach
+- [Docusaurus Documentation](https://docusaurus.io/docs)
+- Official Docusaurus documentation noting its accessibility goals and any local accessibility testing or course template review materials prepared by the department
+
+### 14. Notes
+Docusaurus is an open-source static site generator rather than a closed vendor-managed platform. Accessibility depends both on the framework and on how the course template and student-authored content are implemented. Because course sites may be public, local testing of headings, alt text, color contrast, keyboard navigation, and screen reader behavior remains important even when the framework itself is designed with accessibility in mind.

--- a/documentation/src/pages/technology-accommodations/github.mdx
+++ b/documentation/src/pages/technology-accommodations/github.mdx
@@ -1,0 +1,62 @@
+# GitHub Technology Accommodations
+
+This page summarizes accessibility support and accommodation considerations for GitHub in the capstone course. The sections below are also organized so the same information can be reused for university accessibility review questions when needed.
+
+## Product/Service Information
+
+### 1. Name of Product or Service
+GitHub
+
+### 2. Description and Usage
+GitHub is the course platform for source control, collaboration, pull requests, code review, issue discussion, and publication of project repositories. Students use GitHub to manage version history, collaborate on code and documentation, and publish course artifacts in a way that mirrors professional software development practice.
+
+### 3. Product/Service Website
+- [GitHub](https://github.com/)
+- [GitHub Classroom](https://classroom.github.com/)
+
+### 4. How many individuals will use this product/service?
+More than 100 individuals in a semester. Capstone sections usually enroll about 20 to 25 students each, and there are typically 5 to 6 sections in a semester, which places expected usage above 100 users before including instructors and teaching assistants.
+
+### 5. How many individuals will be required to use this product/service for coursework or job function?
+More than 100 individuals are required to use GitHub for coursework or instructional support in a semester. Capstone sections usually enroll about 20 to 25 students each, and there are typically 5 to 6 sections in a semester, which places required usage above 100 users before including instructors and teaching assistants.
+
+### 6. Intended Audience
+Students and employees. Members of the public may also view public repositories or GitHub Pages sites generated as part of the course.
+
+### 7. Contract Expiration Date
+If GitHub is being used through a specific institutional agreement, the requestor should supply the applicable contract date. If there is no multi-year contract tied to this request, this field may be left blank.
+
+### 8. Are you submitting this request for yourself or on behalf of someone else?
+This is requestor-specific and should be completed by the instructor, staff member, or administrator submitting the form.
+
+## Exception Request Details
+
+### 9. Have you compared this product or service to others?
+Yes.
+
+### 10. Researched Alternatives and Why They Are Not Acceptable Replacements
+- GitLab: A capable platform, but it adds administrative and onboarding overhead for students and does not align as directly with the existing GitHub Classroom, GitHub Pages, and portfolio workflows used in the course.
+- Bitbucket: Supports source control collaboration, but it is less aligned with the public portfolio, GitHub Actions, and classroom onboarding model already established for the course.
+- Gitea or another self-hosted Git service: Would require local administration, infrastructure maintenance, and extra support work that is not appropriate for a semester-long undergraduate capstone course.
+
+### 11. Reasonable Accommodations
+The use of GitHub does not change the learning objectives of the course. Reasonable accommodations may include:
+
+- Blind/Low Vision: Use screen readers, browser zoom, and high-contrast settings; provide accessible written instructions for repository workflows; and allow accessible local Git clients when the web interface is difficult to use.
+- Deaf/Hard of Hearing: Provide captions or transcripts for any instructional videos and ensure communication can occur through written channels such as pull request comments, issues, email, Canvas, or chat.
+- Keyboard-Only Users: Support browser and GitHub keyboard navigation where available and provide workflow guidance that minimizes mouse-only interactions.
+- Speech-to-Text Users: Allow the use of speech recognition tools for editing code, writing pull request comments, and participating in code review.
+- Students with Limited or No Speech: Permit written participation in code reviews, issue discussions, repository documentation, and team coordination rather than requiring verbal participation.
+- Color Blindness: Do not rely only on color cues in diffs, status checks, or labels; use text-based descriptions and written reviewer guidance.
+- Cognitive or Learning Disabilities: Provide step-by-step workflow guides, templates for pull requests and issues, written checklists, and additional time where appropriate.
+- Motor Disabilities: Permit adaptive keyboards, switch devices, eye-tracking tools, alternative pointing devices, and compatible local Git clients.
+
+### 12. Does the vendor have accessibility documentation?
+Yes.
+
+### 13. Accessibility Documentation to Attach
+- [GitHub Accessibility](https://github.com/accessibility)
+- Any current GitHub accessibility statements or conformance materials available at the time of submission
+
+### 14. Notes
+GitHub is central to the course because it supports collaborative version control, peer review, repository history, and public-facing project portfolios. Public exposure should be evaluated based on whether repositories and GitHub Pages sites are configured as public for the semester.

--- a/documentation/src/pages/technology-accommodations/index.mdx
+++ b/documentation/src/pages/technology-accommodations/index.mdx
@@ -1,0 +1,15 @@
+# Technology Accommodations
+
+This page collects accessibility notes, accommodation ideas, and tool-specific support information for the core technologies used in the course.
+
+If you are a student and need support, please also contact Disability Resources and Services and the instructor so we can determine the most effective accommodation for your situation.
+
+## Technology Pages
+
+- [Jira Technology Accommodations](/technology-accommodations/jira)
+- [GitHub Technology Accommodations](/technology-accommodations/github)
+- [Docusaurus Technology Accommodations](/technology-accommodations/docusaurus)
+
+## Additional Notes
+
+These pages are written to be helpful for students and instructional staff, while also organizing the information commonly requested during university accessibility reviews. Semester-specific counts, contract details, and named requestor information should still be confirmed when needed.

--- a/documentation/src/pages/technology-accommodations/jira.mdx
+++ b/documentation/src/pages/technology-accommodations/jira.mdx
@@ -1,0 +1,63 @@
+# Jira Technology Accommodations
+
+This page summarizes accessibility support and accommodation considerations for Jira in the capstone course. The sections below are also organized so the same information can be reused for university accessibility review questions when needed.
+
+## Product/Service Information
+
+### 1. Name of Product or Service
+Jira
+
+### 2. Description and Usage
+Jira is an Agile project management platform used in the course for backlog management, sprint planning, issue tracking, assignment of work, bug reporting, and progress monitoring. Students use Jira to practice industry-standard software engineering workflows without changing the course learning objectives.
+
+### 3. Product/Service Website
+- [Temple Jira Workspace](https://temple-cis-projects-in-cs.atlassian.net/jira/)
+- [Atlassian Jira Product Page](https://www.atlassian.com/software/jira)
+
+### 4. How many individuals will use this product/service?
+More than 100 individuals in a semester. Capstone sections usually enroll about 20 to 25 students each, and there are typically 5 to 6 sections in a semester, which places expected usage above 100 users before including instructors and teaching assistants.
+
+### 5. How many individuals will be required to use this product/service for coursework or job function?
+More than 100 individuals are required to use Jira for coursework or instructional support in a semester. Capstone sections usually enroll about 20 to 25 students each, and there are typically 5 to 6 sections in a semester, which places required usage above 100 users before including instructors and teaching assistants.
+
+### 6. Intended Audience
+Students and employees.
+
+### 7. Contract Expiration Date
+If Jira is provided through an institutional agreement, the requestor should supply the applicable contract date. If there is no multi-year contract tied to this request, this field may be left blank.
+
+### 8. Are you submitting this request for yourself or on behalf of someone else?
+This is requestor-specific and should be completed by the instructor, staff member, or administrator submitting the form.
+
+## Exception Request Details
+
+### 9. Have you compared this product or service to others?
+Yes.
+
+### 10. Researched Alternatives and Why They Are Not Acceptable Replacements
+- Broadcom Rally: A legacy enterprise Agile platform with declining adoption, higher administrative overhead, and a steeper learning curve than Jira for small student teams.
+- GitHub Projects: Useful for lightweight issue tracking, but it does not provide the same depth of Scrum workflows, sprint planning, backlog tooling, or instructor-facing project analytics used in the course.
+- Trello: Easy to learn, but it is better suited to lightweight Kanban workflows than the structured Agile project management practices students are expected to learn.
+
+### 11. Reasonable Accommodations
+The use of Jira does not change the learning objectives of the course. Reasonable accommodations may include:
+
+- Blind/Low Vision: Use screen readers such as JAWS, NVDA, or VoiceOver; allow browser zoom and high-contrast settings; provide accessible written instructions; and provide text descriptions when visual dashboards or diagrams are discussed.
+- Deaf/Hard of Hearing: Provide captions or transcripts for any training videos and ensure project communication can occur through written channels such as Jira comments, email, Canvas, or team chat.
+- Keyboard-Only Users: Support keyboard navigation and documented keyboard workflows where possible through Jira and the web browser.
+- Speech-to-Text Users: Allow the use of speech recognition software to create and edit issues, comments, and related documentation.
+- Students with Limited or No Speech: Permit participation through written communication, documentation, Jira comments, email, and chat rather than requiring verbal participation.
+- Color Blindness: Do not rely solely on color-coded statuses or labels; use text labels, issue titles, and written status descriptions.
+- Cognitive or Learning Disabilities: Provide structured templates, checklists, consistent workflows, written instructions, and additional time where appropriate.
+- Motor Disabilities: Permit assistive input devices such as adaptive keyboards, switch devices, eye-tracking tools, or other browser-compatible assistive technologies.
+
+### 12. Does the vendor have accessibility documentation?
+Yes.
+
+### 13. Accessibility Documentation to Attach
+- [Atlassian Accessibility](https://www.atlassian.com/accessibility)
+- [Atlassian WCAG Resources](https://www.atlassian.com/trust/compliance/resources/wcag)
+- Jira Cloud VPAT or other current Atlassian accessibility conformance materials that apply to the licensed product tier
+
+### 14. Notes
+Atlassian publishes accessibility resources and VPAT materials for Jira products. Jira is widely used in industry, and the course uses it to teach Agile planning and issue management practices that students are expected to encounter in professional software development.

--- a/documentation/static/slides/manifest.json
+++ b/documentation/static/slides/manifest.json
@@ -1,7 +1,0 @@
-{
-  "generatedAt": "2026-06-26T18:16:12.224Z",
-  "groupBy": "week",
-  "groupBasePath": "weeks",
-  "totalSlides": 0,
-  "groups": []
-}

--- a/documentation/static/slides/manifest.json
+++ b/documentation/static/slides/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-30T14:00:53.378Z",
+  "generatedAt": "2026-06-26T18:16:12.224Z",
   "groupBy": "week",
   "groupBasePath": "weeks",
   "totalSlides": 0,

--- a/documentation/syllabus/tools-technology.mdx
+++ b/documentation/syllabus/tools-technology.mdx
@@ -12,6 +12,11 @@ import IframeWindow from '@site/src/components/BrowserWindow/IframeWindow';
 
 
 # Tools and Technologies
+In this course, you will use industry-standard software engineering tools to manage projects, collaborate with your team, maintain source code, and document your work. These technologies were selected because they reflect the workflows and practices commonly used by professional software development teams.
+
+:::note Accessibility
+If you need accessibility information or accommodation support related to course technologies, review the [Technology Accommodations](/technology-accommodations) page and connect with Disability Resources and Services and the instructor if additional support would be helpful.
+:::
 
 <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center' , gap: '24px', marginBottom: '20px'}}>
   <a href="#jira" style={{textAlign: 'center', textDecoration: 'none', color: 'inherit', flex: 1}}>
@@ -29,9 +34,46 @@ import IframeWindow from '@site/src/components/BrowserWindow/IframeWindow';
 </div>
 
 ## Jira
-In this course, you will use tools like Jira for project management and GitHub for version control, ensuring you are prepared for industry practices.
+Jira is an enterprise-grade Agile project management platform developed by Atlassian. It is widely used by software companies to plan projects, manage product backlogs, organize Scrum sprints, track bugs, assign work, and monitor project progress. Throughout this course, you will use Jira to manage your capstone project and gain experience with professional Agile development practices.
 
 <Figure src={jiraBoard} caption="Jira Software Scrum Board"/>
+
+
+Jira is an enterprise-grade project management platform developed by Atlassian. Atlassian publishes accessibility documentation, including WCAG conformance reports and VPAT documents, and states that it is committed to conforming to WCAG 2.2 AA. Jira is designed to support common assistive technologies, including screen readers, keyboard navigation, browser zoom, and high-contrast display settings.
+
+Atlassian accessibility documentation is available here:
+
+- [Atlassian Accessibility](https://www.atlassian.com/accessibility)
+- [Atlassian WCAG Resources](https://www.atlassian.com/trust/compliance/resources/wcag)
+
+### Jira Accessibility and Reasonable Accommodations
+
+The use of Jira does not change the learning objectives of this course. Students who require accommodations should work with Disability Resources and Services and the instructor to determine appropriate accommodations.
+
+<details>
+<summary>Click to expand: Accessibility and Reasonable Accommodations</summary>
+
+Reasonable accommodations may include:
+
+- Blind/Low Vision: Students may use Jira with screen readers such as JAWS, NVDA, or VoiceOver. Browser zoom, high-contrast modes, and accessible written documentation may also be used.
+- Deaf/Hard of Hearing: Captions or transcripts may be provided for instructional videos. Project communication can be provided in written form through Jira comments, email, Canvas, or team chat.
+- Keyboard-Only Users: Students may use keyboard navigation and keyboard shortcuts where supported by Jira and the browser.
+- Speech-to-Text Users: Students may use speech recognition software to create, edit, and comment on Jira issues.
+- Students with Limited or No Speech: Students may participate through written communication, Jira comments, documentation, email, Canvas, or team chat instead of relying only on verbal communication.
+- Color Blindness: Course instructions and project expectations should not rely solely on color-coded Jira statuses or labels. Text labels, issue names, and status names should also be used.
+- Cognitive or Learning Disabilities: Students may use structured templates, checklists, written instructions, consistent workflows, and additional time when appropriate.
+- Motor Disabilities: Students may use assistive input devices, adaptive keyboards, switch devices, eye-tracking tools, or other technologies compatible with modern web browsers.
+
+</details>
+
+### Jira Alternatives Considered
+
+Several alternatives were considered, but Jira was selected because it best supports the professional Agile software engineering practices used in this course.
+
+- Broadcom Rally: A legacy enterprise Agile platform that has seen declining adoption compared to Jira. It is overly complex for small student teams, has a steep learning curve, requires significant administrative overhead, and offers little advantage over Jira for a semester-long capstone course.
+- GitHub Projects: Integrates well with source code but lacks Jira's robust Scrum features, sprint planning, backlog management, burndown reports, and instructor-focused project analytics. It is better suited for lightweight issue tracking than the enterprise Agile workflows students are expected to learn for professional software development.
+- Trello: Easy to learn and suitable for simple Kanban task tracking, but lacks built-in Agile project management features, detailed reporting, and scalability needed for semester-long software engineering projects. It is primarily designed for lightweight task management rather than the structured Agile processes commonly used in industry.
+
 
 ## GitHub
 
@@ -82,4 +124,3 @@ In this course, you will use GitHub to host your project repositories, manage co
 This course requires the use of Canvas, including access to materials and assignment submission.
 On-campus computer labs have resumed normal operations and are available for student use.
 Limited resources are available for students who do not have the technology they need for class. Students with educational technology needs, including no computer or camera or insufficient Wifi-access, should submit a Student Technology Assistance Application located in TUPortal and linked from the [Dean of Students Support and Resources webpage](https://deanofstudents.temple.edu/support-and-resources). The university will endeavor to meet needs, such as with a long-term loan of a laptop or Mifi device, a refurbished computer, or subsidized internet access. [Internet Essentials from Comcast](https://www.internetessentials.com/) provides the option to purchase a computer for $150 and high-speed Internet service for $9.95 a month, plus tax. The [Emergency Broadband Benefit (EBB)](https://www.fcc.gov/broadbandbenefit) is available to purchase Xfinity, Verizon, T-Mobile, and other internet services. Qualified households can receive a temporary monthly credit of up to $50/month toward their Internet service and leased Internet equipment until the program's funding runs out.
-


### PR DESCRIPTION
## Summary
- Add a Technology Accommodations hub page and tool-specific pages for Jira, GitHub, and Docusaurus
- Expand the syllabus technology section with clearer course tool context and accessibility guidance
- Update the slides manifest timestamp to reflect the latest generated output

## Testing
- Not run (not requested)